### PR TITLE
fix: Css styles & redeploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,5 +15,5 @@
 ### Run locally
 
   ```bash
-  bundle exec jekyll serve [--livereload]
+  bundle exec jekyll serve [--livereload] [--config _config_dev.yml]
   ```

--- a/_config.yml
+++ b/_config.yml
@@ -27,7 +27,7 @@ email: louttche@proton.me
 domain: louttche.github.io       # if you want to force HTTPS, specify the domain without the http at the start, e.g. example.com
 url: https://louttche.github.io  # the base hostname and protocol for your site, e.g. http://example.com
 # url: "" # the base hostname & protocol for your site, e.g. http://example.com
-baseurl: ""     # "/louttche.github.io" place folder name if the site is served in a subfolder
+baseurl: "/louttche.github.io"
 # github_username:  louttche
 repository: louttche/louttche.github.io
 # Build settings

--- a/_config_dev.yml
+++ b/_config_dev.yml
@@ -1,0 +1,17 @@
+domain: louttche.github.io
+base_url: ""
+
+# Build settings
+theme: jekyll-theme-midnight
+
+# Collections
+collections:
+  projects:
+    output: true
+    permalink: /projects/:slug/
+    title: Projects
+    description: A collection of my projects.
+
+exclude:
+  - _projects/project_template.markdown
+  - local_assets

--- a/_includes/down.html
+++ b/_includes/down.html
@@ -1,0 +1,20 @@
+<style type="text/css" media="screen">
+  .container {
+    margin: 10px auto;
+    max-width: 600px;
+    text-align: center;
+  }
+  h1 {
+    margin: 30px 0;
+    font-size: 4em;
+    line-height: 1;
+    letter-spacing: -1px;
+  }
+</style>
+
+<div class="container">
+  <h1>Down for maintenance</h1>
+
+  <p><strong>Thank you for visiting my portfolio! Unfortunately it is not up right now... :(</strong></p>
+  <p>Please wait and try again later or contact me <a href="mailto:{{ site.email }}">here</a></p>
+</div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>{{ page.title }}</title>
-    <link rel="stylesheet" href="{{ "/assets/css/styles.css" }}">
+    <link rel="stylesheet" href="{{ site.baseurl }}{{ "/assets/css/styles.css" }}">
 
     <!-- Include JavaScript -->
     <script src="/assets/js/main.js"></script>
@@ -19,28 +19,6 @@
   </head>
 
   <body>
-    <style type="text/css" media="screen">
-      .container {
-        margin: 10px auto;
-        max-width: 600px;
-        text-align: center;
-      }
-      h1 {
-        margin: 30px 0;
-        font-size: 4em;
-        line-height: 1;
-        letter-spacing: -1px;
-      }
-    </style>
-    <div class="container">
-      <h1>Down for maintenance</h1>
-
-      <p><strong>Thank you for visiting my portfolio! Unfortunately it is not up right now... :(</strong></p>
-      <p>Please wait and try again later or contact me <a href="mailto:louttche@proton.me">here</a></p>
-    </div>
-  </body>
-
-  {% comment %} <body>
     <div id="header">
       {% include navigation.html %}
     </div>
@@ -61,5 +39,5 @@
       </div>
     </section>
     <script src="https://cdn.jsdelivr.net/npm/@glidejs/glide/dist/glide.min.js"></script>
-  </body> {% endcomment %}
+  </body>
 </html>


### PR DESCRIPTION
The css styles were messing up on production, so checking if we can fix that by passing the potentially correct base_url to the head style sheets.

Do this by making a separate file for the config when in development and production, so that we can pass `{base_url}/assets/*.css/.js` to the head of the default html, which will be different for development and production.